### PR TITLE
feat: Add tags support to instance group resource

### DIFF
--- a/instance_group.tf
+++ b/instance_group.tf
@@ -49,6 +49,7 @@ resource "ibm_is_instance_group" "instance_group" {
   name               = var.instance_group_name != null ? var.instance_group_name : (var.prefix != null ? "${var.prefix}-ins-group" : "ins-group")
   resource_group     = var.resource_group_id
   access_tags        = var.access_tags
+  tags               = var.tags
   instance_template  = ibm_is_instance_template.instance_template.id
   instance_count     = var.instance_count
   subnets            = var.subnets[*].id

--- a/security_group.tf
+++ b/security_group.tf
@@ -56,6 +56,8 @@ module "security_groups" {
   security_group_rules         = each.value.rules
   resource_group               = var.resource_group_id
   vpc_id                       = var.vpc_id
+  tags                         = var.tags
+  access_tags                  = var.access_tags
 }
 
 ##############################################################################


### PR DESCRIPTION
### Description

- Adds the missing `tags` argument to the `ibm_is_instance_group` resource

issue: https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone-vsi-autoscale/issues/219

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- Adds the missing `tags` argument to the `ibm_is_instance_group` resource, enabling users to apply tags to instance groups created by this module.


### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
